### PR TITLE
Develop html log parsing for cwc sessions.

### DIFF
--- a/get_logs.py
+++ b/get_logs.py
@@ -40,6 +40,21 @@ def get_session_logs(cont):
     return fname
 
 
+def get_bioagent_images(cont):
+    try:
+        bts, meta = cont.get_archive(
+            '/sw/cwc-integ/hms/bioagents/bioagents/images'
+            )
+    except Exception as e:
+        print("WARNING: Failed to get images from the bioagents.")
+        return None
+    arch_name = '%s_bioagent_images.tar.gz' % make_cont_name(cont)
+    with open(arch_name, 'wb') as f:
+        for bit in bts:
+            f.write(bit)
+    return arch_name
+
+
 def format_cont_date(cont):
     cont_date = ('-'.join(cont.attrs['Created'].replace(':', '-')
                  .replace('.', '-').split('-')[:-1]))

--- a/get_logs.py
+++ b/get_logs.py
@@ -67,11 +67,13 @@ def make_cont_name(cont):
 
 
 def get_logs_for_container(cont):
-    ses_log_fname = get_session_logs(cont)
-    run_log_fname = get_run_logs(cont)
-    for fname in [ses_log_fname, run_log_fname]:
+    tasks = [get_session_logs, get_run_logs, get_bioagent_images]
+    fnames = []
+    for task in tasks:
+        fname = task(cont)
+        fnames.append(fname)
         _dump_on_s3(fname)
-    return ses_log_fname, run_log_fname
+    return tuple(fnames)
 
 
 def _dump_on_s3(fname):
@@ -92,13 +94,16 @@ def get_logs():
     cont_list = client.containers.list(True)
     master_logs = []
     log_arches = []
+    img_arches = []
     for cont in cont_list:
-        ses_name, run_name = get_logs_for_container(cont)
+        ses_name, run_name, img_name = get_logs_for_container(cont)
         master_logs.append(ses_name)
         log_arches.append(run_name)
+        img_arches.append(img_name)
     print("Found the following logs:")
     print(master_logs)
     print(log_arches)
+    print(img_arches)
     return
 
 

--- a/get_logs.py
+++ b/get_logs.py
@@ -4,6 +4,8 @@ import docker
 import tarfile
 from io import BytesIO
 
+import logging
+logger = logging.getLogger('log-getter')
 
 def c_ls(container, dirname):
     started = False
@@ -46,7 +48,7 @@ def get_bioagent_images(cont):
             '/sw/cwc-integ/hms/bioagents/bioagents/images'
             )
     except Exception as e:
-        print("WARNING: Failed to get images from the bioagents.")
+        logger.warning("Failed to get images from the bioagents.")
         return None
     arch_name = '%s_bioagent_images.tar.gz' % make_cont_name(cont)
     with open(arch_name, 'wb') as f:
@@ -71,6 +73,7 @@ def get_logs_for_container(cont):
     fnames = []
     for task in tasks:
         fname = task(cont)
+        logger.info("Saved %s locally." % fname)
         fnames.append(fname)
         _dump_on_s3(fname)
     return tuple(fnames)
@@ -85,6 +88,7 @@ def _dump_on_s3(fname):
     with open(fname, 'rb') as f:
         s3.put_object(Key=s3_prefix + fname, Body=f.read(),
                       Bucket=s3_bucket)
+    logger.info("%s dumped on s3." % fname)
     return
 
 

--- a/get_logs.py
+++ b/get_logs.py
@@ -3,7 +3,6 @@ import boto3
 import docker
 import tarfile
 from io import BytesIO
-from datetime import datetime
 
 
 def c_ls(container, dirname):
@@ -57,7 +56,7 @@ def get_logs_for_container(cont):
     run_log_fname = get_run_logs(cont)
     for fname in [ses_log_fname, run_log_fname]:
         _dump_on_s3(fname)
-    return
+    return ses_log_fname, run_log_fname
 
 
 def _dump_on_s3(fname):
@@ -79,14 +78,12 @@ def get_logs():
     master_logs = []
     log_arches = []
     for cont in cont_list:
-        master_logs.append(get_session_logs(cont))
-        log_arches.append(get_run_logs(cont))
+        ses_name, run_name = get_logs_for_container(cont)
+        master_logs.append(ses_name)
+        log_arches.append(run_name)
     print("Found the following logs:")
     print(master_logs)
     print(log_arches)
-    now = datetime.now()
-    for fname in log_arches + master_logs:
-        _dump_on_s3(fname)
     return
 
 

--- a/get_logs.py
+++ b/get_logs.py
@@ -47,7 +47,7 @@ def format_cont_date(cont):
 
 
 def make_cont_name(cont):
-    return '%s_%s_%s' % (cont.image.attrs['Config']['Image'],
+    return '%s_%s_%s' % (cont.image.attrs['Config']['Image'].replace(':', '-'),
                          cont.image.attrs['Config']['Hostname'], cont.name)
 
 

--- a/get_logs.py
+++ b/get_logs.py
@@ -107,6 +107,7 @@ def get_logs_from_s3(folder=None, cached=True):
         # Replace a couple of things in the key to make the actual fname
         fname = key.replace('/', '_')
         fname = fname.replace('bob_ec2_logs_cwc-integ:latest_', '')
+        fname = fname.replace('bob_ec2_logs_cwc-integ_', '')
         fname = fname.replace('.tar.gz', '.txt')
         if folder:
             fname = os.path.join(folder, fname)

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -80,13 +80,14 @@ def format_sys_utterance(msg):
     msg_text = msg.content.get('content').gets('what')
     html = """
     <div class="row sys_utterance" style="margin-top: 15px">
-      <div class="col-sm sys_name" 
-           style="display:inline-block; 
-                  background-color:#2E64FE;
-                  color: #FFFFFF">Bob</div>
-      <div class="col-sm" style="display:inline-block;">&nbsp;</div>
-      <div class="col-sm text-right msg_time"
-           style="display:inline-block;">{time}</div>
+      <div class="col-sm sys_name">
+        <p style="background-color:#2E64FE;
+                  color: #FFFFFF">Bob:
+        </p>&nbsp;
+        <p style="color: #BDBDBD">
+          {time}
+        </p>
+      </div>
     </div>
 
     <div class="row sys_utterance" style="margin-bottom: 15px">
@@ -100,13 +101,14 @@ def format_user_utterance(msg):
     msg_text = msg.content.get('content').gets('text')
     html = """
     <div class="row usr_utterance" style="margin-top: 15px">
-      <div class="col-sm usr_name" 
-        style="display:inline-block; 
-                  background-color: #A5DF00;
-                  color: #FFFFFF">User</div>
-      <div class="col-sm" style="display:inline-block;">&nbsp;</div>
-      <div class="col-sm text-right msg_time" 
-           style="display:inline-block;">{time}</div>
+      <div class="col-sm usr_name">
+        <p style="background-color: #A5DF00;
+                  color: #FFFFFF">User:
+        </p>&nbsp;
+        <p style="color: #BDBDBD">
+          {time}
+        </p>
+      </div>
     </div>
 
     <div class="row usr_utterance" style="margin-bottom: 15px">

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -1,9 +1,11 @@
+import os
 import sys
 import textwrap
 from collections import namedtuple
 from kqml import *
 from bs4 import BeautifulSoup
 
+THIS_DIR = os.path.abspath(os.path.dirname(__file__))
 
 Message = namedtuple('Message', ['type', 'receiver', 'time', 'content', 'sem'])
 
@@ -107,7 +109,7 @@ def format_user_utterance(msg):
 
 
 def make_html(html_parts):
-    with open('page_template.html', 'r') as fh:
+    with open(os.path.join(THIS_DIR, 'page_template.html'), 'r') as fh:
         template = fh.read()
 
     html = template.replace('%%%CONTENT%%%', '\n'.join(html_parts))

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -12,30 +12,118 @@ from kqml import *
 THIS_DIR = os.path.abspath(os.path.dirname(__file__))
 
 
-class Message(object):
+def format_sys_utterance(entry):
+    msg_text = entry.content.get('content').gets('what')
+    html = """
+    <div class="row sys_utterance" style="margin-top: 15px">
+      <div class="col-sm sys_name">
+        <span style="background-color:#2E64FE; color: 
+        #FFFFFF">Bob:</span>&nbsp;<a style="color: #BDBDBD">{time}</a>
+      </div>
+    </div>
+
+    <div class="row sys_utterance" style="margin-bottom: 15px">
+      <div class="col-sm sys_msg">{txt}</div>
+    </div>
+    """.format(time=entry.time, txt=msg_text)
+    return textwrap.dedent(html)
+
+
+def format_user_utterance(entry):
+    msg_text = entry.content.get('content').gets('text')
+    html = """
+    <div class="row usr_utterance" style="margin-top: 15px">
+      <div class="col-sm usr_name">
+        <span style="background-color: #A5DF00; color: 
+        #FFFFFF">User:</span>&nbsp;<a style="color: #BDBDBD">{time}</a>
+      </div>
+    </div>
+
+    <div class="row usr_utterance" style="margin-bottom: 15px">
+      <div class="col-sm usr_msg">{txt}</div>
+    </div>
+    """.format(time=entry.time, txt=msg_text)
+    return textwrap.dedent(html)
+
+
+def format_provenance(entry):
+    prov_html = entry.content.get('content').gets('html')
+    html = """
+    <div class="row add_provenance" style="margin-top: 15px">
+        <div class="col-sm sys_name">
+            <span style="background-color: #2E64FE; color: 
+            #FFFFFF">Bob (provenance):</span>&nbsp;<a style="color:
+            #BDBDBD">{time}</a>
+        </div>
+    </div>
+
+    {provenance_html}
+    """.format(time=entry.time, provenance_html=prov_html)
+    return textwrap.dedent(html)
+
+
+def make_html(html_parts):
+    with open(os.path.join(THIS_DIR, 'page_template.html'), 'r') as fh:
+        template = fh.read()
+
+    html = template.replace('%%%CONTENT%%%', '\n'.join(html_parts))
+    return html
+
+
+def format_start_time(start_time):
+    html = """
+    <div class="row start_time">
+      <div class="col-sm">Dialogue started at: {start_time}</div>
+    </div>
+    """.format(start_time=start_time)
+    return textwrap.dedent(html)
+
+
+class CwcLogEntry(object):
+    """Parent class for entries in the logs."""
     possible_sems = ('sys_utterance', 'user_utterance', 'display_image',
                      'add_provenance', 'display_sbgn')
 
-    def __init__(self, type, partner, time, content):
+    def __init__(self, type, time, message, partner):
         self.type = type
-        self.partner = partner
         self.time = time
-        self.content = content
+        self.message = message
+        self.partner = partner
+        self.content = None
         self.sem = None
-        for sem in self.possible_sems:
-            if self.content_is(sem):
-                self.sem = sem
-                break
         return
+
+    def get_content(self):
+        """Convert the entry to a message."""
+        if not self.content:
+            self.content = KQMLPerformative.from_string(self.message)
+        return self.content
+
+    def get_sem(self):
+        """Get the sem (semantic) of this entry."""
+        if not self.sem:
+            for sem in self.possible_sems:
+                if self._content_is(sem):
+                    self.sem = sem
+                    break
+        return self.sem
+
+    def is_sem(self, sem):
+        """Check whether this entry matches the given sem."""
+        if sem not in self.possible_sems:
+            raise ValueError("Invalid sem: %s" % sem)
+        return self.get_sem() == sem
 
     def _cont_is_type(self, head, content_head):
         try:
-            return (self.content.head().upper() == head.upper() and
-                    self.content.get('content').head().upper() == content_head.upper())
+            my_head = self.content.head()
+            my_content_head = self.content.get('content').head()
+            return (my_head.upper() == head.upper() and
+                    my_content_head.upper() == content_head.upper())
         except Exception as e:
             return False
 
-    def content_is(self, msg_type):
+    def _content_is(self, msg_type):
         simple_types = ['display_image', 'display_sbgn', 'add_provenance']
         if msg_type in simple_types:
             msg_type = msg_type.replace('_', '-')
@@ -56,107 +144,6 @@ class Message(object):
             return False
         logger.warning("Unrecognized message type: %s" % msg_type)
         return False
-
-
-def format_sys_utterance(msg):
-    msg_text = msg.content.get('content').gets('what')
-    html = """
-    <div class="row sys_utterance" style="margin-top: 15px">
-      <div class="col-sm sys_name">
-        <span style="background-color:#2E64FE; color: 
-        #FFFFFF">Bob:</span>&nbsp;<a style="color: #BDBDBD">{time}</a>
-      </div>
-    </div>
-
-    <div class="row sys_utterance" style="margin-bottom: 15px">
-      <div class="col-sm sys_msg">{txt}</div>
-    </div>
-    """.format(time=msg.time, txt=msg_text)
-    return textwrap.dedent(html)
-
-
-def format_user_utterance(msg):
-    msg_text = msg.content.get('content').gets('text')
-    html = """
-    <div class="row usr_utterance" style="margin-top: 15px">
-      <div class="col-sm usr_name">
-        <span style="background-color: #A5DF00; color: 
-        #FFFFFF">User:</span>&nbsp;<a style="color: #BDBDBD">{time}</a>
-      </div>
-    </div>
-
-    <div class="row usr_utterance" style="margin-bottom: 15px">
-      <div class="col-sm usr_msg">{txt}</div>
-    </div>
-    """.format(time=msg.time, txt=msg_text)
-    return textwrap.dedent(html)
-
-
-def format_provenance(msg):
-    prov_html = msg.content.get('content').gets('html')
-    html = """
-    <div class="row add_provenance" style="margin-top: 15px">
-        <div class="col-sm sys_name">
-            <span style="background-color: #2E64FE; color: 
-            #FFFFFF">Bob (provenance):</span>&nbsp;<a style="color:
-            #BDBDBD">{time}</a>
-        </div>
-    </div>
-
-    {provenance_html}
-    """.format(time=msg.time, provenance_html=prov_html)
-    return textwrap.dedent(html)
-
-
-def make_html(html_parts):
-    with open(os.path.join(THIS_DIR, 'page_template.html'), 'r') as fh:
-        template = fh.read()
-
-    html = template.replace('%%%CONTENT%%%', '\n'.join(html_parts))
-    return html
-
-
-def get_io_msgs(log):
-    io_msgs = []
-    entry_list = log.all
-    for entry in entry_list:
-        try:
-            msg = entry.to_message()
-        except Exception:
-            continue
-        if msg.sem is not None:
-            io_msgs.append(msg)
-    return io_msgs
-
-
-def format_start_time(start_time):
-    html = """
-    <div class="row start_time">
-      <div class="col-sm">Dialogue started at: {start_time}</div>
-    </div>
-    """.format(start_time=start_time)
-    return textwrap.dedent(html)
-
-
-class CwcLogEntry(object):
-    """Parent class for entries in the logs."""
-
-    def __init__(self, type, time, message, partner):
-        self.type = type
-        self.time = time
-        self.message = message
-        self.partner = partner
-        self.content = None
-        return
-
-    def to_message(self):
-        """Convert the entry to a message."""
-        if not self.content:
-            self.content = KQMLPerformative.from_string(self.message)
-
-        # Add message semantics
-        msg = Message(self.type, self.partner, self.time, self.content)
-        return msg
 
     def __repr__(self):
         ret = '<%s ' % self.__class__.__name__
@@ -181,25 +168,58 @@ class CwcLog(object):
 
     def __init__(self, log_dir):
         self.log_dir = log_dir
+
+        # Load and parse the log file.
         self.log_file = os.path.join(log_dir, 'log.txt')
         with open(self.log_file, 'r') as f:
             self.__log = f.read()
-        tp = self.time_patt.search(self.__log)
-        assert tp is not None, "Failed to get time string."
-        self.start_time = ' '.join(tp.groups())
-        sec_list = self.section_patt.findall(self.__log)
-        assert sec_list, "Failed to find any sections."
-        self.sent = []
-        self.received = []
-        self.all = []
-        for typ, dt, other_type, partner, msg in sec_list:
-            entry = CwcLogEntry(typ, dt, msg, partner)
-            if typ == 'S':
-                self.sent.append(entry)
-            else:
-                self.received.append(entry)
-            self.all.append(entry)
+        self.start_time = None
+        self.all_entries = None
+
+        # Get familiar with the image stash, if present.
+        self.img_dir = os.path.join(log_dir, 'images')
+        if not os.path.exists(self.img_dir):
+            # If the logs are old and there's no image directory, we'll just
+            # have to live without images.
+            logger.warning("No image directory \"%s\" found. This transcript "
+                           "will have no images included." % self.img_dir)
+            self.img_dir = None
+
+        # This is filled later.
+        self.io_entries = None
         return
+
+    def get_start_time(self):
+        if self.start_time is None:
+            tp = self.time_patt.search(self.__log)
+            assert tp is not None, "Failed to get time string."
+            self.start_time = ' '.join(tp.groups())
+        return self.start_time
+
+    def get_all_entries(self):
+        if self.all_entries is None:
+            self.all_entries = []
+            sec_list = self.section_patt.findall(self.__log)
+            assert sec_list, "Failed to find any sections."
+            for typ, dt, other_type, partner, msg in sec_list:
+                entry = CwcLogEntry(typ, dt, msg, partner)
+                self.all_entries.append(entry)
+        return self.all_entries
+
+    def get_io_entries(self):
+        if not self.io_entries:
+            self.io_entries = []
+            entry_list = self.get_all_entries()
+            for entry in entry_list:
+                try:
+                    entry.get_content()
+                except KQMLException:
+                    logger.debug("Failed to get content for:\n%s."
+                                 % repr(entry))
+                    continue
+                if entry.get_sem() is not None:
+                    self.io_entries.append(entry)
+        return self.io_entries
 
 
 def logs_to_html_file(log_dir_path, html_file=None):
@@ -210,21 +230,20 @@ def logs_to_html_file(log_dir_path, html_file=None):
 
     html_parts = ['<div class="container">']
 
-    start_time = log.start_time
+    start_time = log.get_start_time()
     html_parts.append(format_start_time(start_time))
 
     # Find all messages received by the BA
-    io_msgs = get_io_msgs(log)
-    for msg in io_msgs:
-        if msg.sem == 'sys_utterance':
-            print('SYS: %s' % msg.content)
-            html_parts.append(format_sys_utterance(msg))
-        elif msg.sem == 'user_utterance':
-            print('USER: %s' % msg.content)
-            html_parts.append(format_user_utterance(msg))
-        elif msg.sem == 'add_provenance':
+    for entry in log.get_io_entries():
+        if entry.is_sem('sys_utterance'):
+            print('SYS: %s' % entry.get_content())
+            html_parts.append(format_sys_utterance(entry))
+        elif entry.is_sem('user_utterance'):
+            print('USER: %s' % entry.get_content())
+            html_parts.append(format_user_utterance(entry))
+        elif entry.is_sem('add_provenance'):
             print('SYS: <sent content to provenance>')
-            html_parts.append(format_provenance(msg))
+            html_parts.append(format_provenance(entry))
     html_parts.append('</div>')
 
     with open(html_file, 'w') as fh:

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -53,6 +53,7 @@ class Message(object):
             if sen.upper() == 'TEXTTAGGER' \
                     and self._cont_is_type('tell', 'utterance'):
                 return True
+            return False
         logger.warning("Unrecognized message type: %s" % msg_type)
         return False
 
@@ -156,7 +157,7 @@ class CwcLogEntry(object):
 
 class CwcLog(object):
     """Object to organize the logs retrieved from cwc facilitator.log."""
-    section_patt = re.compile('<(?P<type>S|R)\s+T=\"(?P<time>.*?)\"\s+'
+    section_patt = re.compile('<(?P<type>S|R)\s+T=\"(?P<time>[\d.:]+)\"\s+'
                               '(?P<other_type>S|R)=\"(?P<sender>\w+)\">'
                               '\s+(?P<msg>.*?)\s+</(?P=type)>', re.DOTALL)
     time_patt = re.compile('<LOG TIME=\"(.*?)\"\s+DATE=\"(.*?)\".*?>')

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -130,7 +130,7 @@ def get_io_msgs(log):
 
 
 def format_start_time(start_time):
-    html= """
+    html = """
     <div class="row start_time">
       <div class="col-sm">Dialogue started at: {start_time}</div>
     </div>
@@ -179,8 +179,10 @@ class CwcLog(object):
                               '\s+(?P<msg>.*?)\s+</(?P=type)>', re.DOTALL)
     time_patt = re.compile('<LOG TIME=\"(.*?)\"\s+DATE=\"(.*?)\".*?>')
 
-    def __init__(self, log_file):
-        with open(log_file, 'r') as f:
+    def __init__(self, log_dir):
+        self.log_dir = log_dir
+        self.log_file = os.path.join(log_dir, 'log.txt')
+        with open(self.log_file, 'r') as f:
             self.__log = f.read()
         tp = self.time_patt.search(self.__log)
         assert tp is not None, "Failed to get time string."
@@ -200,11 +202,11 @@ class CwcLog(object):
         return
 
 
-def log_file_to_html_file(log_file, html_file=None):
+def logs_to_html_file(log_dir_path, html_file=None):
     if html_file is None:
-        html_file = log_file[:-4] + '.html'
+        html_file = os.path.join(log_dir_path, 'transcript.html')
 
-    log = CwcLog(log_file)
+    log = CwcLog(log_dir_path)
 
     html_parts = ['<div class="container">']
 
@@ -230,5 +232,4 @@ def log_file_to_html_file(log_file, html_file=None):
 
 
 if __name__ == '__main__':
-    log_file = sys.argv[1]
-    log_file_to_html_file(log_file)
+    logs_to_html_file(sys.argv[1])

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -299,9 +299,9 @@ def export_logs(log_dir_path, out_file=None, file_type='html', use_cache=True):
     if file_type not in ['pdf', 'html']:
         raise ValueError("Invalid file type: %s." % file_type)
 
-    html_file = os.path.join(log_dir_path, 'transcript.' + file_type)
+    html_file = os.path.join(log_dir_path, 'transcript.html')
     if out_file is None:
-        out_file = html_file
+        out_file = html_file.replace('html', file_type)
 
     if not use_cache or not os.path.exists(html_file):
         log = CwcLog(log_dir_path)

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -63,7 +63,9 @@ class CwcLogEntry(object):
             <div class="col-sm {col_sm}">
                 <span style="background-color:{back_clr}; color:{fore_clr}">
                     {name}:
-                </span>&nbsp;<a style="color: #BDBDBD">{time}</a>
+                </span>&nbsp;<a style="color: #BDBDBD">
+                    at {time} from the {ag}
+                    </a>
             </div>
         </div>
 
@@ -108,7 +110,10 @@ class CwcLogEntry(object):
                 img_loc = os.path.abspath(os.path.join(self.log_dir, img_loc))
             inp = ('<img src=\"{img}\" alt=\"Image {img} Not Available\">'
                    .format(img=img_loc))
-            name = 'Bob (%s)' % cont.gets('type')
+            img_type = cont.gets('type')
+            if img_type == 'simulation' and self.partner == 'QCA':
+                img_type = 'path_diagram'
+            name = 'Bob (%s)' % img_type
             back_clr = bob_back
             col_sm = 'sys_name'
             msg_sm = 'sys_image'
@@ -117,7 +122,7 @@ class CwcLogEntry(object):
         return textwrap.dedent(fmt.format(time=self.time, inp=inp, name=name,
                                           col_sm=col_sm, msg_sm=msg_sm,
                                           back_clr=back_clr, fore_clr=fore_clr,
-                                          sem=self.get_sem()))
+                                          sem=self.get_sem(), ag=self.partner))
 
     def _cont_is_type(self, head, content_head):
         try:

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -77,15 +77,40 @@ def make_html(html_parts):
     return html
 
 
+def get_ba_msgs(soup):
+    ba_tags = soup.find_all('s', attrs={'r': 'BA'})
+    ba_msgs = [tag_to_message(tag) for tag in ba_tags]
+    return ba_msgs
+
+
+def get_start_time(soup):
+    # <LOG TIME="9:04 PM" DATE="7/26/18" FILE="facilitator.log">
+    log = soup.find('log')
+    start_time = log.attrs['date'] + ' ' + log.attrs['time']
+    return start_time
+
+
+def format_start_time(start_time):
+    html= """
+    <div class="row start_time">
+      <div class="col-sm">Dialogue started at: {start_time}</div>
+    </div>
+    """.format(start_time=start_time)
+    return textwrap.dedent(html)
+
+
 if __name__ == '__main__':
     with open(sys.argv[1], 'r') as fh:
         log = fh.read()
 
     soup = BeautifulSoup(log, 'html.parser')
-    # Find all messages received by the BA
-    ba_tags = soup.find_all('s', attrs={'r': 'BA'})
-    ba_msgs = [tag_to_message(tag) for tag in ba_tags]
     html_parts = ['<div class="container">']
+
+    start_time = get_start_time(soup)
+    html_parts.append(format_start_time(start_time))
+
+    # Find all messages received by the BA
+    ba_msgs = get_ba_msgs(soup)
     for msg in ba_msgs:
         if is_sys_utterance(msg):
             print('SYS: %s' % msg.content)

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -270,6 +270,26 @@ class CwcLog(object):
 
 
 def export_logs(log_dir_path, out_file=None, file_type='html'):
+    """Export the logs in log_dir_path into html or pdf.
+
+    Parameters
+    ----------
+    log_dir_path : str
+        The path to the log directory which should contain log.txt and a
+        directory called 'images'.
+    out_file : str
+        By default this will be a file 'transcript.html' or 'transcript.pdf' in
+        the log_dir_path, depending on the file_type. If an out_file is
+        specified, the file_type is over-ruled by the file ending.
+    file_type : 'html' or 'pdf'
+        Specify the output file time. If an out_file is specified, the type
+        implied by the file will override this parameter. Default is 'html'.
+
+    Returns
+    -------
+    out_file : str
+        The path to the output file.
+    """
     file_type = file_type.lower()
     if out_file and out_file.endswith('.pdf'):
         file_type = 'pdf'
@@ -293,6 +313,7 @@ def export_logs(log_dir_path, out_file=None, file_type='html'):
             return
         pdfkit.from_string(html, out_file)
     logger.info("Result saved to %s." % out_file)
+    return out_file
 
 
 if __name__ == '__main__':

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -81,7 +81,8 @@ def format_sys_utterance(msg):
     html = """
     <div class="row sys_utterance" style="margin-top: 15px">
       <div class="col-sm sys_name">
-        <p style="background-color:#2E64FE; color: #FFFFFF">Bob:</p>&nbsp;<p style="color: #BDBDBD">{time}</p>
+        <span style="background-color:#2E64FE; color: 
+        #FFFFFF">Bob:</span>&nbsp;<a style="color: #BDBDBD">{time}</a>
       </div>
     </div>
 
@@ -97,7 +98,8 @@ def format_user_utterance(msg):
     html = """
     <div class="row usr_utterance" style="margin-top: 15px">
       <div class="col-sm usr_name">
-        <p style="background-color: #A5DF00; color: #FFFFFF">User:</p>&nbsp;<p style="color: #BDBDBD">{time}</p>
+        <span style="background-color: #A5DF00; color: 
+        #FFFFFF">User:</span>&nbsp;<a style="color: #BDBDBD">{time}</a>
       </div>
     </div>
 

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -269,7 +269,7 @@ class CwcLog(object):
         return make_html(html_parts)
 
 
-def export_logs(log_dir_path, out_file=None, file_type='html'):
+def export_logs(log_dir_path, out_file=None, file_type='html', use_cache=True):
     """Export the logs in log_dir_path into html or pdf.
 
     Parameters
@@ -284,6 +284,9 @@ def export_logs(log_dir_path, out_file=None, file_type='html'):
     file_type : 'html' or 'pdf'
         Specify the output file time. If an out_file is specified, the type
         implied by the file will override this parameter. Default is 'html'.
+    use_cache : bool
+        Default is True. If True, re-use previous results as stashed in the
+        log directory structure.
 
     Returns
     -------
@@ -296,16 +299,21 @@ def export_logs(log_dir_path, out_file=None, file_type='html'):
     if file_type not in ['pdf', 'html']:
         raise ValueError("Invalid file type: %s." % file_type)
 
+    html_file = os.path.join(log_dir_path, 'transcript.' + file_type)
     if out_file is None:
-        out_file = os.path.join(log_dir_path, 'transcript.' + file_type)
+        out_file = html_file
 
-    log = CwcLog(log_dir_path)
-    html = log.make_html()
+    if not use_cache or not os.path.exists(html_file):
+        log = CwcLog(log_dir_path)
+        html = log.make_html()
 
-    if file_type == 'html':
-        with open(out_file, 'w') as fh:
+        with open(html_file, 'w') as fh:
             fh.write(html)
-    elif file_type == 'pdf':
+    else:
+        with open(html_file, 'r') as fh:
+            html = fh.read()
+
+    if file_type == 'pdf':
         try:
             import pdfkit
         except ImportError:

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -81,7 +81,9 @@ def format_sys_utterance(msg):
     html = """
     <div class="row sys_utterance" style="margin-top: 15px">
       <div class="col-sm sys_name" 
-           style="display:inline-block; color: #D0FA58">Bob</div>
+           style="display:inline-block; 
+                  background-color:#2E64FE;
+                  color: #FFFFFF">Bob</div>
       <div class="col-sm" style="display:inline-block;">&nbsp;</div>
       <div class="col-sm text-right msg_time"
            style="display:inline-block;">{time}</div>
@@ -99,7 +101,9 @@ def format_user_utterance(msg):
     html = """
     <div class="row usr_utterance" style="margin-top: 15px">
       <div class="col-sm usr_name" 
-        style="display:inline-block; color: #2ECCFA">User</div>
+        style="display:inline-block; 
+                  background-color: #A5DF00;
+                  color: #FFFFFF">User</div>
       <div class="col-sm" style="display:inline-block;">&nbsp;</div>
       <div class="col-sm text-right msg_time" 
            style="display:inline-block;">{time}</div>

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -80,9 +80,11 @@ def format_sys_utterance(msg):
     msg_text = msg.content.get('content').gets('what')
     html = """
     <div class="row sys_utterance">
-      <div class="col-sm sys_name">Bob</div>
-      <div class="col-sm">&nbsp;</div>
-      <div class="col-sm text-right msg_time">{time}</div>
+      <div class="col-sm sys_name" 
+           style="display:inline-block; color: #D0FA58">Bob</div>
+      <div class="col-sm" style="display:inline-block;">&nbsp;</div>
+      <div class="col-sm text-right msg_time"
+           style="display:inline-block;">{time}</div>
     </div>
 
     <div class="row sys_utterance">
@@ -96,9 +98,11 @@ def format_user_utterance(msg):
     msg_text = msg.content.get('content').gets('text')
     html = """
     <div class="row usr_utterance">
-      <div class="col-sm usr_name">User</div>
-      <div class="col-sm">&nbsp;</div>
-      <div class="col-sm text-right msg_time">{time}</div>
+      <div class="col-sm usr_name" 
+        style="display:inline-block; color: #2ECCFA">User</div>
+      <div class="col-sm" style="display:inline-block;">&nbsp;</div>
+      <div class="col-sm text-right msg_time" 
+           style="display:inline-block;">{time}</div>
     </div>
 
     <div class="row usr_utterance">

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -141,6 +141,18 @@ class CwcLogEntry(object):
         msg = Message(self.type, self.partner, self.time, self.content)
         return msg
 
+    def __repr__(self):
+        ret = '<%s ' % self.__class__.__name__
+        ret += self.type + ' to ' if self.type == 'S' else ' from '
+        nmax = 50
+        if len(self.message) <= nmax:
+            msg_str = self.message
+        else:
+            msg_str = self.message[:(nmax-3)] + '...'
+        ret += self.partner + ": \"%s\"" % msg_str
+        ret += '>'
+        return ret
+
 
 class CwcLog(object):
     """Object to organize the logs retrieved from cwc facilitator.log."""

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -75,14 +75,14 @@ class CwcLogEntry(object):
         usr_back = '#A5DF00'
         fore_clr = '#FFFFFF'
         if self.is_sem('sys_utterance'):
-            print('SYS:', str(self.content)[:100])
+            print('SYS:', str(self.content)[:500])
             inp = cont.gets('what')
             name = 'Bob'
             back_clr = bob_back
             col_sm = 'sys_name'
             msg_sm = 'sys_msg'
         elif self.is_sem('user_utterance'):
-            print('USR:', str(self.content)[:100])
+            print('USR:', str(self.content)[:500])
             inp = cont.gets('text')
             name = 'User'
             back_clr = usr_back
@@ -108,7 +108,7 @@ class CwcLogEntry(object):
                 img_loc = os.path.abspath(os.path.join(self.log_dir, img_loc))
             inp = ('<img src=\"{img}\" alt=\"Image {img} Not Available\">'
                    .format(img=img_loc))
-            name = 'Bob'
+            name = 'Bob (%s)' % cont.gets('type')
             back_clr = bob_back
             col_sm = 'sys_name'
             msg_sm = 'sys_image'

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -79,7 +79,7 @@ def is_user_utterance(msg, receiver):
 def format_sys_utterance(msg):
     msg_text = msg.content.get('content').gets('what')
     html = """
-    <div class="row sys_utterance">
+    <div class="row sys_utterance" style="margin-top: 15px">
       <div class="col-sm sys_name" 
            style="display:inline-block; color: #D0FA58">Bob</div>
       <div class="col-sm" style="display:inline-block;">&nbsp;</div>
@@ -87,7 +87,7 @@ def format_sys_utterance(msg):
            style="display:inline-block;">{time}</div>
     </div>
 
-    <div class="row sys_utterance">
+    <div class="row sys_utterance" style="margin-bottom: 15px">
       <div class="col-sm sys_msg">{txt}</div>
     </div>
     """.format(time=msg.time, txt=msg_text)
@@ -97,7 +97,7 @@ def format_sys_utterance(msg):
 def format_user_utterance(msg):
     msg_text = msg.content.get('content').gets('text')
     html = """
-    <div class="row usr_utterance">
+    <div class="row usr_utterance" style="margin-top: 15px">
       <div class="col-sm usr_name" 
         style="display:inline-block; color: #2ECCFA">User</div>
       <div class="col-sm" style="display:inline-block;">&nbsp;</div>
@@ -105,7 +105,7 @@ def format_user_utterance(msg):
            style="display:inline-block;">{time}</div>
     </div>
 
-    <div class="row usr_utterance">
+    <div class="row usr_utterance" style="margin-bottom: 15px">
       <div class="col-sm usr_msg">{txt}</div>
     </div>
     """.format(time=msg.time, txt=msg_text)

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -1,4 +1,5 @@
 import sys
+import textwrap
 from collections import namedtuple
 from kqml import *
 from bs4 import BeautifulSoup
@@ -36,6 +37,46 @@ def is_user_utterance(msg):
         return False
 
 
+def format_sys_utterance(msg):
+    msg_text = msg.content.get('content').gets('what')
+    html = """
+    <div class="row sys_utterance">
+      <div class="col-sm sys_name">Bob</div>
+      <div class="col-sm">&nbsp;</div>
+      <div class="col-sm text-right msg_time">{time}</div>
+    </div>
+
+    <div class="row sys_utterance">
+      <div class="col-sm sys_msg">{txt}</div>
+    </div>
+    """.format(time=msg.time, txt=msg_text)
+    return textwrap.dedent(html)
+
+
+def format_user_utterance(msg):
+    msg_text = msg.content.get('content').gets('text')
+    html = """
+    <div class="row usr_utterance">
+      <div class="col-sm usr_name">User</div>
+      <div class="col-sm">&nbsp;</div>
+      <div class="col-sm text-right msg_time">{time}</div>
+    </div>
+
+    <div class="row usr_utterance">
+      <div class="col-sm usr_msg">{txt}</div>
+    </div>
+    """.format(time=msg.time, txt=msg_text)
+    return textwrap.dedent(html)
+
+
+def make_html(html_parts):
+    with open('page_template.html', 'r') as fh:
+        template = fh.read()
+
+    html = template.replace('%%%CONTENT%%%', '\n'.join(html_parts))
+    return html
+
+
 if __name__ == '__main__':
     with open(sys.argv[1], 'r') as fh:
         log = fh.read()
@@ -44,8 +85,14 @@ if __name__ == '__main__':
     # Find all messages received by the BA
     ba_tags = soup.find_all('s', attrs={'r': 'BA'})
     ba_msgs = [tag_to_message(tag) for tag in ba_tags]
+    html_parts = ['<div class="container">']
     for msg in ba_msgs:
         if is_sys_utterance(msg):
             print('SYS: %s' % msg.content)
+            html_parts.append(format_sys_utterance(msg))
         elif is_user_utterance(msg):
             print('USER: %s' % msg.content)
+            html_parts.append(format_user_utterance(msg))
+    html_parts.append('</div>')
+    with open('test.html', 'w') as fh:
+        fh.write(make_html(html_parts))

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -81,12 +81,7 @@ def format_sys_utterance(msg):
     html = """
     <div class="row sys_utterance" style="margin-top: 15px">
       <div class="col-sm sys_name">
-        <p style="background-color:#2E64FE;
-                  color: #FFFFFF">Bob:
-        </p>&nbsp;
-        <p style="color: #BDBDBD">
-          {time}
-        </p>
+        <p style="background-color:#2E64FE; color: #FFFFFF">Bob:</p>&nbsp;<p style="color: #BDBDBD">{time}</p>
       </div>
     </div>
 
@@ -102,12 +97,7 @@ def format_user_utterance(msg):
     html = """
     <div class="row usr_utterance" style="margin-top: 15px">
       <div class="col-sm usr_name">
-        <p style="background-color: #A5DF00;
-                  color: #FFFFFF">User:
-        </p>&nbsp;
-        <p style="color: #BDBDBD">
-          {time}
-        </p>
+        <p style="background-color: #A5DF00; color: #FFFFFF">User:</p>&nbsp;<p style="color: #BDBDBD">{time}</p>
       </div>
     </div>
 

--- a/logs/style.css
+++ b/logs/style.css
@@ -1,3 +1,7 @@
+.start_time {
+    background-color: #ffeaea;
+}
+
 .sys_utterance {
     background-color: #d1e5ff;
 }

--- a/logs/style.css
+++ b/logs/style.css
@@ -1,9 +1,10 @@
 .sys_utterance {
-    background-color: lightblue
+    background-color: #d1e5ff;
 }
 
+
 .usr_utterance {
-    background-color: lightgreen
+    background-color: #ddffdb;
 }
 
 .sys_name {


### PR DESCRIPTION
This PR changes how we get logs from containers, now also grabbing the newly available "images" directory. A function is also added that downloads all the desired logs from s3. Ultimately, PR adds `logs/process_logs.py`, with the principle function `export_logs`, which takes the logs downloaded from s3 and creates either html or pdf (generated from the html) transcripts of the conversation.