### PR TITLE
Add more metadata to logs

### DIFF
--- a/cwc_integ_app.py
+++ b/cwc_integ_app.py
@@ -77,8 +77,8 @@ def _record_my_container(cont_id, action):
             success = False
         elif action == 'remove':
             date = id_dict.pop(cont_id)
-            logger.info("Removing %s from list of my containers which was started "
-                  "at %s." % (cont_id, date))
+            logger.info("Removing %s from list of my containers which was "
+                        "started at %s." % (cont_id, date))
     if success:
         _dump_id_dict(id_dict)
     return success
@@ -104,12 +104,14 @@ def _check_timers():
         # Grab the date from the latest SPG log entry.
         cont = client.containers.get(cont_id)
         cont_logs = cont.logs()
-        date_strings = re.findall('SPG:\s+;;\s+\[(.*?)\]', cont_logs.decode('utf-8'))
+        date_strings = re.findall('SPG:\s+;;\s+\[(.*?)\]',
+                                  cont_logs.decode('utf-8'))
         if date_strings:
-            latest_log_date = datetime.strptime(date_strings[-1], '%m/%d/%Y %H:%M:%S')
+            latest_log_date = datetime.strptime(date_strings[-1],
+                                                '%m/%d/%Y %H:%M:%S')
         else:
-            logger.info("WARNING: Did not find any date strings in container logs "
-                  "for %s." % cont_id)
+            logger.info("WARNING: Did not find any date strings in container "
+                        "logs for %s." % cont_id)
             latest_log_date = start_date
 
         # Check both whether the logs have been silent for more than a day
@@ -118,8 +120,8 @@ def _check_timers():
         log_stalled = (now - latest_log_date).seconds
         total_dur = (now - start_date).seconds
         if log_stalled > 3600:
-            logger.info("Container %s timed out after %d seconds of empty logs."
-                  % (cont_id, log_stalled))
+            logger.info("Container %s timed out after %ds of empty logs."
+                        % (cont_id, log_stalled))
             _stop_container(cont_id)
         elif total_dur > DAY/2:
             logger.info("Container %s timed out after %d seconds of running."
@@ -322,6 +324,7 @@ def monitor():
         logger.info("Monitor is closing with:")
         logger.exception(e)
     return
+
 
 if __name__ == '__main__':
     from sys import argv

--- a/cwc_integ_app.py
+++ b/cwc_integ_app.py
@@ -58,30 +58,40 @@ def _dump_id_dict(id_dict):
     return
 
 
-def _record_my_container(cont_id, action):
-    """Update the json containing the statuses of the containers."""
-    assert action in ['add', 'remove'], "Invalid action: %s" % action
+def _add_my_container(cont_id, interface):
+    """Update the json with a new container."""
     id_dict = _load_id_dict()
 
-    success = True
     if cont_id not in id_dict.keys():
-        if action == 'add':
-            logger.info("Adding %s to list of my containers." % cont_id)
-            id_dict[cont_id] = datetime.utcnow()
-        elif action == 'remove':
-            logger.info("This container isn't mine or doesn't exist.")
-            success = False
-    else:
-        if action == 'add':
-            logger.info("This container was already registered.")
-            success = False
-        elif action == 'remove':
-            date = id_dict.pop(cont_id)
-            logger.info("Removing %s from list of my containers which was "
-                        "started at %s." % (cont_id, date))
-    if success:
+        logger.info("Adding %s to list of my containers." % cont_id)
+        id_dict[cont_id] = (interface, datetime.utcnow())
         _dump_id_dict(id_dict)
+        success = True
+    else:
+        logger.info("This container was already registered.")
+        success = False
+
     return success
+
+
+def _pop_my_container(cont_id, pop=True):
+    """Update the json with the removal of a container."""
+    id_dict = _load_id_dict()
+
+    if cont_id not in id_dict.keys():
+        logger.info("This container isn't mine or doesn't exist.")
+        ret = None
+    else:
+        if pop:
+            ret = id_dict.pop(cont_id)
+        else:
+            ret = id_dict.get(cont_id)
+        logger.info("Removing %s from list of my containers which was "
+                    "started at %s using the %s interface."
+                    % (cont_id,) + ret)
+        _dump_id_dict(id_dict)
+
+    return ret
 
 
 def _check_timers():
@@ -208,7 +218,7 @@ def _launch_app(interface_port_num, app_name, extension=''):
     base_host = 'http://' + str(request.host).split(':')[0]
     host = base_host + (':%d' % port + extension)
     logger.info('Will redirect to address: %s' % host)
-    cont_id = _run_container(port, interface_port_num)
+    cont_id = _run_container(port, interface_port_num, app_name)
     logger.info('Start redirecting %s interface.' % app_name)
     return render_template('launch_dialogue.html', dialogue_url=host,
                            manager_url=base_host, container_id=cont_id,
@@ -250,13 +260,15 @@ def stop_session(cont_id):
 
 
 def _stop_container(cont_id, remove_record=True):
+    record = _pop_my_container(cont_id, pop=remove_record)
     if remove_record:
-        assert _record_my_container(cont_id, 'remove'), \
+        assert record is not None, \
             "Could not remove container because it is not my own."
+    interface, date = record
     client = docker.from_env()
     cont = client.containers.get(cont_id)
     logger.info("Got container %s, aka %s." % (cont.id, cont.name))
-    get_logs_for_container(cont)
+    get_logs_for_container(cont, interface)
     cont.stop()
     cont.remove()
     logger.info("Container removed.")
@@ -264,7 +276,7 @@ def _stop_container(cont_id, remove_record=True):
     return
 
 
-def _run_container(port, expose_port):
+def _run_container(port, expose_port, app_name):
     num_sessions = increment_sessions()
     logger.info('We now have %d active sessions' % num_sessions)
     client = docker.from_env()
@@ -272,9 +284,9 @@ def _run_container(port, expose_port):
                                  '/sw/cwc-integ/startup.sh',
                                  detach=True,
                                  ports={('%d/tcp' % expose_port): port})
-    logger.info('Launched container %s exposing port %d via port %d' %
-          (cont, expose_port, port))
-    _record_my_container(cont.id, 'add')
+    logger.info('Launched container %s exposing port %d via port %d'
+                % (cont, expose_port, port))
+    _add_my_container(cont.id, app_name)
     return cont.id
 
 

--- a/cwc_integ_app.py
+++ b/cwc_integ_app.py
@@ -224,11 +224,12 @@ def _launch_app(interface_port_num, app_name, extension=''):
     base_host = 'http://' + str(request.host).split(':')[0]
     host = base_host + (':%d' % port + extension)
     logger.info('Will redirect to address: %s' % host)
-    cont_id = _run_container(port, interface_port_num, app_name)
+    cont_id, cont_name = _run_container(port, interface_port_num, app_name)
     logger.info('Start redirecting %s interface.' % app_name)
     return render_template('launch_dialogue.html', dialogue_url=host,
                            manager_url=base_host, container_id=cont_id,
-                           time_out=90)
+                           time_out=90, container_name=cont_name,
+                           interface=app_name)
 
 
 class ClicForm(Form):
@@ -292,7 +293,7 @@ def _run_container(port, expose_port, app_name):
     logger.info('Launched container %s exposing port %d via port %d'
                 % (cont, expose_port, port))
     _add_my_container(cont.id, app_name)
-    return cont.id
+    return cont.id, cont.name
 
 
 def reset_sessions():

--- a/logs/get_logs.py
+++ b/logs/get_logs.py
@@ -73,8 +73,7 @@ def make_cont_name(cont):
                                  '%Y-%m-%dT%H:%M:%S')
     img_id = '%s-%s' % (cont.image.attrs['Id'].split(':')[1][:12],
                         img_date.strftime('%Y%m%d%H%M%S'))
-    return '%s_%s_%s' % (img_id, cont.attrs['Id'].split(':')[1][:12],
-                         cont.name)
+    return '%s_%s_%s' % (img_id, cont.attrs['Id'][:12], cont.name)
 
 
 def get_logs_for_container(cont):

--- a/logs/get_logs.py
+++ b/logs/get_logs.py
@@ -80,8 +80,15 @@ def get_logs_for_container(cont, interface):
     tasks = [get_session_logs, get_run_logs, get_bioagent_images]
     fnames = []
     for task in tasks:
+        # Get the logs.
         fname = task(cont)
-        fname = interface + '-' + fname
+
+        # Rename the log file. This is a little hacky, but it should work.
+        new_fname = interface + '-' + fname
+        os.rename(fname, new_fname)
+        fname = new_fname
+
+        # Add the file to s3.
         logger.info("Saved %s locally." % fname)
         fnames.append(fname)
         _dump_on_s3(fname)

--- a/logs/get_logs.py
+++ b/logs/get_logs.py
@@ -141,7 +141,7 @@ def get_logs_from_s3(folder=None, cached=True):
     # facilitator
     print(len(keys))
     print(len([k for k in keys if 'image' in k]))
-    keys = [key for key in keys if key.startswith('bob_ec2_logs/cwc-integ')
+    keys = [key for key in keys if key.startswith('bob_ec2_logs/')
             and key.endswith('.tar.gz')]
     print(len(keys))
     print('Found %d keys' % len(keys))
@@ -151,7 +151,10 @@ def get_logs_from_s3(folder=None, cached=True):
     for key in tqdm.tqdm(keys):
         fname = os.path.basename(key)
         m = fname_patt.match(fname)
-        assert m is not None, "Failed to match %s" % fname_patt
+        if m is None:
+            logger.warning("File name %s failed to match %s. Skipping..."
+                           % (fname, fname_patt))
+            continue
         image_id, cont_hash, cont_name, resource_name = m.groups()
         head_dir_path = '%s_%s_%s' % (image_id.replace(':', '-'), cont_name,
                                       cont_hash)

--- a/logs/get_logs.py
+++ b/logs/get_logs.py
@@ -76,11 +76,12 @@ def make_cont_name(cont):
     return '%s_%s_%s' % (img_id, cont.attrs['Id'][:12], cont.name)
 
 
-def get_logs_for_container(cont):
+def get_logs_for_container(cont, interface):
     tasks = [get_session_logs, get_run_logs, get_bioagent_images]
     fnames = []
     for task in tasks:
         fname = task(cont)
+        fname = interface + '-' + fname
         logger.info("Saved %s locally." % fname)
         fnames.append(fname)
         _dump_on_s3(fname)

--- a/logs/index_template.html
+++ b/logs/index_template.html
@@ -41,7 +41,7 @@
         })
         function loadList() {
             // Load the json list of transcripts
-            return $.ajax({url: "transcripts.json", dataType: "json"});
+            return $.ajax({url: "transcripts.json", dataType: "json", mimeType: "application/json"});
         }
         function moveTo (new_idx) {
             // Go to the indicated value.

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -121,7 +121,7 @@ class CwcLogEntry(object):
             msg_sm = 'sys_image'
         elif self.is_sem('reset'):
             print("------------- RESET -----------")
-            return "<hr width=\"75%\">"
+            return "<hr width=\"75%\" size=\"3\" noshade>"
         else:
             return None
         return textwrap.dedent(fmt.format(time=self.time, inp=inp, name=name,

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -25,7 +25,7 @@ def make_html(html_parts):
 class CwcLogEntry(object):
     """Parent class for entries in the logs."""
     possible_sems = ('sys_utterance', 'user_utterance', 'display_image',
-                     'add_provenance', 'display_sbgn')
+                     'add_provenance', 'display_sbgn', 'reset')
 
     def __init__(self, type, time, message, partner, log_dir):
         self.type = type
@@ -94,7 +94,7 @@ class CwcLogEntry(object):
             msg_sm = 'usr_msg'
         elif self.is_sem('add_provenance'):
             print("SYS sent provenance.")
-            inp = cont.gets('html')
+            inp = cont.gets('html').replace('<hr>', '')
             name = 'Bob (provenance)'
             back_clr = bob_back
             col_sm = 'sys_name'
@@ -119,6 +119,9 @@ class CwcLogEntry(object):
             back_clr = bob_back
             col_sm = 'sys_name'
             msg_sm = 'sys_image'
+        elif self.is_sem('reset'):
+            print("------------- RESET -----------")
+            return "<hr width=\"75%\">"
         else:
             return None
         return textwrap.dedent(fmt.format(time=self.time, inp=inp, name=name,
@@ -154,6 +157,14 @@ class CwcLogEntry(object):
                     and self._cont_is_type('tell', 'utterance'):
                 return True
             return False
+        elif msg_type == 'reset':
+            is_shout = (self.partner and self.partner.upper() == 'BA' and
+                        self._cont_is_type('broadcast', 'tell'))
+            if not is_shout:
+                return False
+            inner_content = self.content.get('content').get('content')
+            return (is_shout and inner_content
+                    and inner_content.head().upper() == 'START-CONVERSATION')
         logger.warning("Unrecognized message type: %s" % msg_type)
         return False
 

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -339,7 +339,7 @@ if __name__ == '__main__':
     transcripts.sort()
     json_fname = os.path.join(loc, 'transcripts.json')
     with open(json_fname, 'w') as f:
-        json.dump([os.path.abspath(of) for _, of in transcripts], f)
+        json.dump([os.path.abspath(of) for _, of in transcripts], f, indent=1)
     with open(os.path.join(THIS_DIR, 'index_template.html'), 'r') as f:
         html_template = f.read()
     html = html_template.replace('{{date}}', str(datetime.now()))

--- a/logs/process_logs.py
+++ b/logs/process_logs.py
@@ -207,6 +207,21 @@ class CwcLog(object):
             res = m.groups()
         self.image_id, self.container_name, self.container_hash = res
 
+        # Get the interface from the image_id if available.
+        if self.image_id.lower().startswith('clic'):
+            self.interface = 'CLIC'
+            self.image_id = self.image_id[4:].lstrip('-')
+        elif self.image_id.lower().startswith('sbgn'):
+            self.interface = 'SBGN'
+            self.image_id = self.image_id[4:].lstrip('-')
+        else:
+            self.interface = 'UNKNOWN'
+
+        # Get the date out of the image name, if present.
+        # WARNING: This way of doing it will break in around 80 years.
+        if '-20' in self.image_id:
+            self.image_id = self.image_id.split('-')[0]
+
         # Get familiar with the image stash, if present.
         self.img_dir = os.path.join(log_dir, IMG_DIRNAME)
         if not os.path.exists(self.img_dir):
@@ -262,11 +277,12 @@ class CwcLog(object):
         html = """
         <div class="row start_time">
           <div class="col-sm">
-            Dialogue with {container} running image {image} started at: {start}
+            Dialogue running {container} container with image {image} using
+            the {interface} interface started at: {start}
           </div>
         </div>
         """.format(start=self.get_start_time(), container=self.container_name,
-                   image=self.image_id)
+                   image=self.image_id, interface=self.interface)
         return textwrap.dedent(html)
 
     def make_html(self):

--- a/templates/launch_dialogue.html
+++ b/templates/launch_dialogue.html
@@ -44,11 +44,14 @@
     </div>
 </div>
 <div class="container">
+    <div id="session_div" align="center" class="well well-sm">
+        You are running on the docker container named {{container_name}}
+        using the {{interface}} interface.
+    </div>
     <div id="end_div" align="center" class="well well-sm">
         When done, click this button to end your session:
         <button type="button" onclick="submit_delete()">End Session</button>
     </div>
-    
 </div>
 <div id="dialogue_div" style="display: none;">
     <iframe align="middle" width="1700" height="1500" src="" id="dialogue_frame" frameborder="0" allowfullscreen>


### PR DESCRIPTION
This PR adds:
- docker image hashes (truncated) instead of the label, so that the image can be better traced.
- hr lines upon RESET
- dates are now included in the file names (henceforth, not retroactively)
- the interface used is included in the log heading.